### PR TITLE
sandboxR GH repository moved

### DIFF
--- a/vignettes/document.bib
+++ b/vignettes/document.bib
@@ -377,7 +377,7 @@ url = {http://had.co.nz/ggplot2/book},
   title={The \pkg{sandboxR} package: Filtering "malicious" Calls in \R},
   author={Gergely Daroczi},
   year={2012},
-  url= {https://github.com/daroczig/sandboxR}
+  url= {https://github.com/rapporter/sandboxR}
 }
 
 @article{banfield1999rweb,


### PR DESCRIPTION
Hi Jeroen,

I have moved the `sandboxR` repository to our organizational account on GH a few months ago, it might be a good idea to also update its URL in your vignette.
