### PR TITLE
Add a tolerance to reliably detect timeouts

### DIFF
--- a/R/eval.secure.R
+++ b/R/eval.secure.R
@@ -179,7 +179,7 @@ eval.secure <- function(..., uid, gid, priority, profile, timeout=60,
 
 	#timeout?
 	if(is.null(myresult)){
-    if(isTRUE(timeout > 0 && totaltime+5 > timeout)){
+    if(isTRUE(timeout > 0 && totaltime >= timeout)){
 		  stop("R call did not return within ", timeout, " seconds. Terminating process.", call.=FALSE);
     } else {
       stop("R call failed: process died.", call.=FALSE);

--- a/R/eval.secure.R
+++ b/R/eval.secure.R
@@ -179,7 +179,7 @@ eval.secure <- function(..., uid, gid, priority, profile, timeout=60,
 
 	#timeout?
 	if(is.null(myresult)){
-    if(isTRUE(timeout > 0 && totaltime >= timeout)){
+    if(isTRUE(timeout > 0 && totaltime + 0.1 >= timeout)){
 		  stop("R call did not return within ", timeout, " seconds. Terminating process.", call.=FALSE);
     } else {
       stop("R call failed: process died.", call.=FALSE);

--- a/R/eval.secure.R
+++ b/R/eval.secure.R
@@ -179,7 +179,7 @@ eval.secure <- function(..., uid, gid, priority, profile, timeout=60,
 
 	#timeout?
 	if(is.null(myresult)){
-    if(isTRUE(timeout > 0 && totaltime + .1 >= timeout)){
+    if(isTRUE(timeout > 0 && totaltime >= timeout)){
 		  stop("R call did not return within ", timeout, " seconds. Terminating process.", call.=FALSE);
     } else {
       stop("R call failed: process died.", call.=FALSE);

--- a/R/eval.secure.R
+++ b/R/eval.secure.R
@@ -179,7 +179,7 @@ eval.secure <- function(..., uid, gid, priority, profile, timeout=60,
 
 	#timeout?
 	if(is.null(myresult)){
-    if(isTRUE(timeout > 0 && totaltime > timeout)){
+    if(isTRUE(timeout > 0 && totaltime+5 > timeout)){
 		  stop("R call did not return within ", timeout, " seconds. Terminating process.", call.=FALSE);
     } else {
       stop("R call failed: process died.", call.=FALSE);

--- a/R/eval.secure.R
+++ b/R/eval.secure.R
@@ -179,7 +179,7 @@ eval.secure <- function(..., uid, gid, priority, profile, timeout=60,
 
 	#timeout?
 	if(is.null(myresult)){
-    if(isTRUE(timeout > 0 && totaltime >= timeout)){
+    if(isTRUE(timeout > 0 && totaltime + .1 >= timeout)){
 		  stop("R call did not return within ", timeout, " seconds. Terminating process.", call.=FALSE);
     } else {
       stop("R call failed: process died.", call.=FALSE);


### PR DESCRIPTION
Starting about a month ago I found that timeouts (which I test nightly using Sys.sleep()) started intermittently failing with

 R call failed: process died.

instead of the usual

 R call did not return within x seconds. Terminating process.

Changing > to >= was not sufficient - I had to add a small amount.  I guess that apparmor has become a little more aggressive about timing out, or there are some rounding problems with the timer.

I am using Ubuntu 14.04.5 LTS.

I totally understand if you reject this pull, but I thought it would be worth sharing my experiences and I prefer not to live on a branch.